### PR TITLE
Valkyrie-Translator: Add install targets, delete remnant config files

### DIFF
--- a/catkin_ws/src/valkyrie_translator/CMakeLists.txt
+++ b/catkin_ws/src/valkyrie_translator/CMakeLists.txt
@@ -34,8 +34,11 @@ target_link_libraries(LCM2ROSControl ${catkin_LIBRARIES} )
 pods_use_pkg_config_packages(LCM2ROSControl lcm drc-lcmtypes)
 
 
-## Install
-install(TARGETS ${PROJECT_NAME}
+#############
+## Install ##
+#############
+
+install(TARGETS
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/catkin_ws/src/valkyrie_translator/CMakeLists.txt
+++ b/catkin_ws/src/valkyrie_translator/CMakeLists.txt
@@ -32,3 +32,21 @@ include_directories(
 add_library(LCM2ROSControl src/LCM2ROSControl.cpp)
 target_link_libraries(LCM2ROSControl ${catkin_LIBRARIES} )
 pods_use_pkg_config_packages(LCM2ROSControl lcm drc-lcmtypes)
+
+
+## Install
+install(TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+  PATTERN ".svn" EXCLUDE
+)
+install(DIRECTORY config/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
+  PATTERN ".svn" EXCLUDE
+)
+install(FILES LCM2ROSControl.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/catkin_ws/src/valkyrie_translator/config/simple_val_knee.yaml
+++ b/catkin_ws/src/valkyrie_translator/config/simple_val_knee.yaml
@@ -1,5 +1,0 @@
-simple_val_knee:
-    type: valkyrie_translator/SimpleController
-    joints:
-        - rightKneePitch
-        - leftKneePitch

--- a/catkin_ws/src/valkyrie_translator/config/val_knee.yaml
+++ b/catkin_ws/src/valkyrie_translator/config/val_knee.yaml
@@ -1,2 +1,0 @@
-val_knee:
-    type: valkyrie_translator/LCM2ROSControl


### PR DESCRIPTION
NASA convention is to use ``catkin_make install`` and source the install directory instead of sourcing the devel directory. @alexrobotics has seen SMTCore crashing if it is not installed and run from the install space. This, however, lead to the requirement to source both devel and install if wanting to run the valkyrie translator together with val_gazebo. This PR adds install targets to the valkyrie_translator package to fix this. Besides, two old config files from initial development are removed.