### PR TITLE
Disable atlas collection, flycapture, ptgrey by default

### DIFF
--- a/software/drivers/tobuild.txt
+++ b/software/drivers/tobuild.txt
@@ -3,8 +3,8 @@
 
 multisense
 ipwebcam
-flycapture
-ptgrey
+#flycapture
+#ptgrey
 robotiqhand
 irobothand
 openni

--- a/software/tobuild.txt
+++ b/software/tobuild.txt
@@ -10,6 +10,6 @@ drivers
 utils
 perception
 motion_estimate
-atlas-collection
+#atlas-collection
 control
 director/distro/pods/drc


### PR DESCRIPTION
Disables building of atlas-collection, flycapture, and ptgrey by default. The changes in this PR would need to be manually reverted on the Atlas control computers and should not affect anyone else.

Dependent on #36 

Addresses https://github.com/openhumanoids/oh-distro/issues/38 

Tested on a "public, no-matlab, no private-externals" build on a fresh Ubuntu install.