### PR TITLE
Address #82 (public build)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -334,6 +334,19 @@ These options are disabled by default on purpose. Then, to make use of the syste
     mkdir pod-build && cd pod-build
     cmake .. -DUSE_SYSTEM_PCL:BOOL=ON -DUSE_SYSTEM_OPENCV:BOOL=ON
 
+
+Using externally installed Gurobi
+=================================
+If installing your own version of Gurobi, please add the following to your .bashrc file before compiling oh-distro (and after sourcing drc_environment.sh since these variables will also be set when sourcing our drc_environment config):
+
+::
+
+    export GUROBI_HOME=[PATH_TO]/gurobi/gurobi562/linux64
+    export PATH=$PATH:$GUROBI_HOME/bin
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GUROBI_HOME/lib
+    export GRB_LICENSE_FILE=$HOME/gurobi.lic
+
+
 Build Issues FAQ
 ================
 ISSUE: make in externals failed:

--- a/software/control/CMakeLists.txt
+++ b/software/control/CMakeLists.txt
@@ -4,7 +4,13 @@ cmake_minimum_required(VERSION 2.6.0)
 set(POD_NAME control)
 include(cmake/pods.cmake)
 
-# check whether matlab is present, else skip the entire control directory
+# check whether snopt is available, else skip the control/matlab directory
+pods_find_pkg_config(snopt_c)
+if (NOT snopt_c_FOUND)
+  message(WARNING "SNOPT not found, skipping control/matlab")
+endif()
+
+# check whether matlab is present, else skip the control/matlab directory
 find_program(matlab matlab)
 if (NOT matlab)
   message(WARNING "Matlab not found, skipping control")
@@ -48,7 +54,7 @@ endif()
 
 include_directories(${INCLUDE_INSTALL_PATH})
 
-if (matlab)
+if (matlab AND snopt_c_FOUND)
   add_subdirectory(src)
   add_subdirectory(matlab/@QPReactiveRecoveryPlan)
 endif()
@@ -91,7 +97,6 @@ if (matlab)
            COMMAND testAtlasFallDetector)
 endif()
 
-#find_program(matlab matlab)
 #if (NOT matlab-NOTFOUND)
 #   add_test(NAME MATLAB_Unit_Tests
 #   		 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
- Added note on how to set the path to an external version of Gurobi to the README (untested)
- Changed control CMakeLists so that it also checks the present of SNOPT before adding control/matlab to the build sequence (tested)

Addresses parts of #82 