### PR TITLE
Fix bot_core_lcmtypes build under Ubuntu

### DIFF
--- a/software/externals/cmake/externals.cmake
+++ b/software/externals/cmake/externals.cmake
@@ -11,7 +11,7 @@ if(NOT USE_SYSTEM_LCM)
     )
 endif()
 
-set(bot_core_lcmtypes_url https://github.com/openhumanoids/bot_core_lcmtypes.git)
+set(bot_core_lcmtypes_url https://github.com/iamwolf/bot_core_lcmtypes.git)
 set(bot_core_lcmtypes_revision c29cd6076d13ca2a3ecc23ffcbe28a0a1ab46314)
 set(bot_core_lcmtypes_depends ${lcm_proj})
 

--- a/software/externals/cmake/externals.cmake
+++ b/software/externals/cmake/externals.cmake
@@ -12,7 +12,7 @@ if(NOT USE_SYSTEM_LCM)
 endif()
 
 set(bot_core_lcmtypes_url https://github.com/openhumanoids/bot_core_lcmtypes.git)
-set(bot_core_lcmtypes_revision e873dd4c088fddbbcec88d64fa8aa4bb278d361c)
+set(bot_core_lcmtypes_revision c29cd6076d13ca2a3ecc23ffcbe28a0a1ab46314)
 set(bot_core_lcmtypes_depends ${lcm_proj})
 
 set(libbot_url https://github.com/openhumanoids/libbot.git)


### PR DESCRIPTION
openhumanoids/bot_core_lcmtypes#3 broke a lot of our build, cf. [CDash](http://kobol.csail.mit.edu/cd/viewBuildError.php?buildid=22665). The cause of this is that the libname is now sanitised so either contains an underscore instead of a hyphen or alternatively does not allow a hyphen followed by one word since CMake would interpret this is as a utility. This PR brings in a fork where the CMakeLists were reverted to before that change to allow us to build master again while we are debugging bot_core_lcmtypes' CMake files